### PR TITLE
feat: insertTextAt command

### DIFF
--- a/android/src/main/java/com/typerich/TypeRichTextInputViewManager.kt
+++ b/android/src/main/java/com/typerich/TypeRichTextInputViewManager.kt
@@ -179,6 +179,10 @@ class TypeRichTextInputViewManager :
     view?.setValue(text)
   }
 
+  override fun insertTextAt(view: TypeRichTextInputView?,start:Int,end:Int, text:String) {
+    view?.insertTextAt(start,end, text)
+  }
+
   override fun setSelection(
     view: TypeRichTextInputView?,
     start: Int,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -27,7 +27,15 @@ import { useEffect, useRef, useState } from 'react';
 export default function App() {
   const inputRef = useRef<TypeRichTextInputRef>(null);
   const textRef = useRef('hello world');
+  const selectionRef = useRef<{ start: number; end: number }>({
+    start: 0,
+    end: 0,
+  });
   const [image, setImage] = useState<onPasteImageEventData | null>(null);
+
+  const multilineValue = `hello
+    div
+    multiline`;
 
   // const handleChangeText = (e: NativeSyntheticEvent<OnChangeTextEvent>) => {
   //   console.log('Text changed:', e?.nativeEvent.value);
@@ -41,11 +49,9 @@ export default function App() {
     inputRef.current?.blur();
   };
 
-  const handleSetValue = () => {
-    const multilineValue = `hello
-    div
-    multiline`;
-    inputRef.current?.setValue(multilineValue);
+  const handleSetValue = (value = 'default value') => {
+    textRef.current = value;
+    inputRef.current?.setValue(value);
   };
 
   const handleSetSelection = () => {
@@ -70,6 +76,24 @@ export default function App() {
     inputRef.current?.setValue('draft simulation test');
     textRef.current = 'draft simulation test'; // Update textRef too
   }, []);
+
+  function handleSelectionChange(e: {
+    start: number;
+    end: number;
+    text: string;
+  }): void {
+    console.log('selectionChange called', e);
+    selectionRef.current = { start: e.start, end: e.end };
+  }
+
+  const handleInsertTextAtCursor = () => {
+    const textToInsert = 'Test';
+    inputRef.current?.insertTextAt(
+      selectionRef.current.start,
+      selectionRef.current.end,
+      textToInsert
+    );
+  };
 
   return (
     <>
@@ -100,9 +124,7 @@ export default function App() {
             }}
             onFocus={handleFocusEvent}
             onBlur={handleBlurEvent}
-            onChangeSelection={(e) => {
-              console.log('start', e);
-            }}
+            onChangeSelection={handleSelectionChange}
             // androidExperimentalSynchronousEvents={
             //   ANDROID_EXPERIMENTAL_SYNCHRONOUS_EVENTS
             // }
@@ -128,9 +150,9 @@ export default function App() {
           // multiline={false}
           // numberOfLines={2}
         />
-        <View>
+        <View style={styles.btnContainer}>
           <View style={styles.buttonStack}>
-            <Pressable onPress={handleFocus} style={styles.button}>
+            <Pressable onPress={handleFocus} style={[styles.button]}>
               <Text style={styles.label2}>Focus</Text>
             </Pressable>
             <Pressable onPress={handleBlur} style={styles.button}>
@@ -138,7 +160,18 @@ export default function App() {
             </Pressable>
           </View>
           <View style={styles.buttonStack}>
-            <Pressable onPress={handleSetValue} style={styles.button}>
+            <Pressable onPress={() => handleSetValue('')} style={styles.button}>
+              <Text style={styles.label2}>clear Text</Text>
+            </Pressable>
+            <Pressable onPress={handleInsertTextAtCursor} style={styles.button}>
+              <Text style={styles.label2}>insert "Test" at cursor</Text>
+            </Pressable>
+          </View>
+          <View style={styles.buttonStack}>
+            <Pressable
+              onPress={() => handleSetValue(multilineValue)}
+              style={styles.button}
+            >
               <Text style={styles.label2}>Set value to hello div</Text>
             </Pressable>
             <Pressable onPress={handleSetSelection} style={styles.button}>
@@ -267,6 +300,10 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: 'white',
   },
+  btnContainer: {
+    rowGap: 16,
+  },
+
   content: {
     flexGrow: 1,
     padding: 16,
@@ -298,7 +335,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 15,
     borderRadius: 25,
-    marginVertical: 25,
   },
   valueButton: {
     width: '100%',

--- a/src/TypeRichTextInput.tsx
+++ b/src/TypeRichTextInput.tsx
@@ -55,6 +55,7 @@ export interface TypeRichTextInputRef {
   focus: () => void;
   blur: () => void;
   setValue: (text: string) => void;
+  insertTextAt: (start: number, end: number, text: string) => void;
   setSelection: (start: number, end: number) => void;
   getNativeRef: () => any | null;
 }
@@ -95,6 +96,11 @@ const TypeRichTextInput = forwardRef(
       setSelection(start, end) {
         if (isAndroid && nativeRef.current) {
           Commands.setSelection(nativeRef.current, start, end);
+        }
+      },
+      insertTextAt: (start: number, end: number, text: string) => {
+        if (isAndroid && nativeRef.current) {
+          Commands.insertTextAt(nativeRef.current, start, end, text);
         }
       },
       getNativeRef: () => nativeRef.current,

--- a/src/TypeRichTextInputNativeComponent.ts
+++ b/src/TypeRichTextInputNativeComponent.ts
@@ -78,6 +78,12 @@ interface NativeCommands {
   focus: (viewRef: React.ElementRef<ComponentType>) => void;
   blur: (viewRef: React.ElementRef<ComponentType>) => void;
   setValue: (viewRef: React.ElementRef<ComponentType>, text: string) => void;
+  insertTextAt: (
+    viewRef: React.ElementRef<ComponentType>,
+    start: Int32,
+    end: Int32,
+    text: string
+  ) => void;
   setSelection: (
     viewRef: React.ElementRef<ComponentType>,
     start: Int32,
@@ -92,6 +98,7 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'blur',
     'setValue',
     'setSelection',
+    'insertTextAt',
   ],
 });
 


### PR DESCRIPTION
new command to introduced to reduce manual work
- insert text at the given start and end pos ( if you want to insert text at cursor, store selection in `ref` on `onChangeSelection`)
- reliable: updates the selection automatically

tested and ready to use