### PR TITLE
feat: new faster setText()

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -97,9 +97,7 @@ export default function App() {
     selectionRef.current = { start: e.start, end: e.end };
   }
 
-  const handleInsertTextAtCursor = () => {
-    const insert = 'Test';
-
+  const handleInsertTextAtCursor = (insert = 'Test') => {
     const { start, end } = selectionRef.current;
     const currentText = textRef.current ?? '';
 
@@ -122,7 +120,7 @@ export default function App() {
       }
 
       const index = Math.floor(Math.random() * randomWords.length);
-      handleSetValue(textRef.current + randomWords[index]);
+      handleInsertTextAtCursor(randomWords[index]);
 
       i++;
     }, 100); // 100ms
@@ -168,7 +166,6 @@ export default function App() {
             // }
             multiline
             // numberOfLines={5} // prefer maxHeight on iOS
-            scrollEnabled={false}
             onPasteImageData={(e) => {
               setImage(e);
               console.log(e);
@@ -208,7 +205,10 @@ export default function App() {
             <Pressable onPress={() => handleSetValue('')} style={styles.button}>
               <Text style={styles.label2}>clear Text</Text>
             </Pressable>
-            <Pressable onPress={handleInsertTextAtCursor} style={styles.button}>
+            <Pressable
+              onPress={() => handleInsertTextAtCursor('Test')}
+              style={styles.button}
+            >
               <Text style={styles.label2}>insert "Test" at cursor</Text>
             </Pressable>
           </View>

--- a/ios/modules/commands/TypeRichTextInputCommands.mm
+++ b/ios/modules/commands/TypeRichTextInputCommands.mm
@@ -19,7 +19,7 @@
     _textView = textView;
     _owner = owner;
     
-    // KEY FIX: Serial queue for commands
+    // Serial queue for commands
     _commandQueue = [[NSOperationQueue alloc] init];
     _commandQueue.maxConcurrentOperationCount = 1;
     _commandQueue.qualityOfService = NSQualityOfServiceUserInteractive;
@@ -57,147 +57,115 @@
 
 #pragma mark - Text Commands
 
-/// setText(text)
+/// setText(text) - diff-based with proper cursor tracking, non-undoable
 - (void)setText:(NSString *)text
 {
   UITextView *tv = _textView;
   TypeRichTextInputView *owner = _owner;
   if (!tv || !owner) return;
 
+  dispatch_async(dispatch_get_main_queue(), ^{
+    // Never interrupt IME composition
+    if (tv.markedTextRange) return;
+    
+    NSString *newText = text ?: @"";
+    NSString *currentText = tv.text ?: @"";
+    
+    // commented for now as causing issues when textinput is blank
+    // if ([currentText isEqualToString:newText]) {
+    //    return;
+    // }
 
-    dispatch_async(dispatch_get_main_queue(), ^{
-      if (tv.markedTextRange) return;
-      if (owner.isUserTyping) return;
-
-      NSString *newText = text ?: @"";
-
-      owner.blockEmitting = YES;
-
-      NSTextStorage *storage = tv.textStorage;
-
-      NSRange oldSelection = tv.selectedRange;
+    owner.blockEmitting = YES;
+    
+    NSRange oldSelection = tv.selectedRange;
+    
+    // Calculate minimal diff range
+    NSRange diffRange = [self calculateDiffRange:currentText newText:newText];
+    
+    // Calculate what text will be inserted
+    NSInteger newLength = newText.length - (currentText.length - diffRange.length);
+    NSString *replacementText = @"";
+    
+    if (newLength > 0) {
+      replacementText = [newText substringWithRange:NSMakeRange(diffRange.location, newLength)];
+    }
+    
+    // Convert NSRange to UITextRange
+    UITextPosition *start = [tv positionFromPosition:tv.beginningOfDocument
+                                              offset:diffRange.location];
+    UITextPosition *end = [tv positionFromPosition:tv.beginningOfDocument
+                                            offset:NSMaxRange(diffRange)];
+    
+    if (start && end) {
+      UITextRange *range = [tv textRangeFromPosition:start toPosition:end];
+      [tv replaceRange:range withText:replacementText];
       
-      NSDictionary *attrs = [self baseAttributesForTextView:tv];
-
-      NSAttributedString *attrText =
-        [[NSAttributedString alloc] initWithString:newText
-                                        attributes:attrs];
-
-      [storage beginEditing];
-      [storage setAttributedString:attrText];
-      [storage endEditing];
-
-      // Clamp & restore selection
-      NSInteger max = newText.length;
-      NSInteger loc = MIN(oldSelection.location, max);
-      NSInteger len = MIN(oldSelection.length, max - loc);
-      tv.selectedRange = NSMakeRange(loc, len);
-
-      owner.blockEmitting = NO;
-
-      [owner updatePlaceholderVisibilityFromCommand];
+      // Calculate cursor adjustment
+      NSInteger delta = replacementText.length - diffRange.length;
+      NSInteger newCursorPos = oldSelection.location;
+      
+      // If change happened before cursor, adjust cursor position
+      if (diffRange.location <= oldSelection.location) {
+        newCursorPos = oldSelection.location + delta;
+      }
+      
+      // Clamp to valid range
+      newCursorPos = MAX(0, MIN(newCursorPos, newText.length));
+      
+      // Restore cursor at adjusted position
+      tv.selectedRange = NSMakeRange(newCursorPos, 0);
+      
+    } else {
+      // Fallback: full replace with cursor clamping
+      tv.text = newText;
+      NSInteger safeLoc = MIN(oldSelection.location, newText.length);
+      tv.selectedRange = NSMakeRange(safeLoc, 0);
+    }
+    
+    owner.blockEmitting = NO;
+    
+    [owner updatePlaceholderVisibilityFromCommand];
+    
+    if (tv.scrollEnabled) {
       [owner invalidateTextLayoutFromCommand];
-      [owner dispatchSelectionChangeIfNeeded];
-//
-//    // Restore cursor (clamped)
-//    NSInteger safeOffset = MIN(cursorOffset, newText.length);
-//    UITextPosition *pos =
-//      [tv positionFromPosition:tv.beginningOfDocument
-//                        offset:safeOffset];
-//
-//    if (pos) {
-//      tv.selectedTextRange =
-//        [tv textRangeFromPosition:pos toPosition:pos];
-//    }
-//
-//    owner.blockEmitting = NO;
-//
-//    [owner updatePlaceholderVisibilityFromCommand];
-//    [owner invalidateTextLayoutFromCommand];
-//    [owner dispatchSelectionChangeIfNeeded];
+      
+      // scroll to cursor
+      [tv scrollRangeToVisible:tv.selectedRange];
+    }
+    
+    [owner dispatchSelectionChangeIfNeeded];
   });
 }
 
-/// setText(text) — undoable, cursor-safe, IME-safe
-//- (void)setText:(NSString *)text
-//{
-//  UITextView *tv = _textView;
-//  TypeRichTextInputView *owner = _owner;
-//  if (!tv || !owner) return;
-//
-//  dispatch_async(dispatch_get_main_queue(), ^{
-//    // Never touch text while IME composing
-//    if (tv.markedTextRange) return;
-//
-//    NSString *newText = text ?: @"";
-//    NSString *oldText = tv.text ?: @"";
-//
-//    // No-op fast path
-//    if ([oldText isEqualToString:newText]) {
-//      return;
-//    }
-//
-//    owner.blockEmitting = YES;
-//
-//    // Save selection (cursor)
-//    NSRange oldSelection = tv.selectedRange;
-//
-//    // Compute minimal diff range
-//    NSRange replaceRange = DiffRange(oldText, newText);
-//
-//    NSInteger insertStart = replaceRange.location;
-//    NSInteger insertLength =
-//      newText.length - (oldText.length - replaceRange.length);
-//
-//    NSString *insertText =
-//      insertLength > 0
-//        ? [newText substringWithRange:
-//            NSMakeRange(insertStart, insertLength)]
-//        : @"";
-//
-//    // Convert NSRange → UITextRange
-//    UITextPosition *start =
-//      [tv positionFromPosition:tv.beginningOfDocument
-//                        offset:replaceRange.location];
-//    UITextPosition *end =
-//      [tv positionFromPosition:tv.beginningOfDocument
-//                        offset:NSMaxRange(replaceRange)];
-//
-//    if (!start || !end) {
-//      owner.blockEmitting = NO;
-//      return;
-//    }
-//
-//    UITextRange *uiRange =
-//      [tv textRangeFromPosition:start toPosition:end];
-//
-//    // THIS IS THE KEY LINE (undo-safe)
-//    [tv replaceRange:uiRange withText:insertText];
-//
-//    // ---- Restore selection correctly ----
-//    NSInteger delta = insertText.length - replaceRange.length;
-//
-//    NSInteger newLoc = oldSelection.location;
-//    NSInteger newLen = oldSelection.length;
-//
-//    if (oldSelection.location > replaceRange.location) {
-//      newLoc = MAX(0, newLoc + delta);
-//    }
-//
-//    NSInteger max = tv.text.length;
-//    newLoc = MIN(newLoc, max);
-//    newLen = MIN(newLen, max - newLoc);
-//
-//    tv.selectedRange = NSMakeRange(newLoc, newLen);
-//
-//    owner.blockEmitting = NO;
-//
-//    [owner updatePlaceholderVisibilityFromCommand];
-//    [owner invalidateTextLayoutFromCommand];
-//    [owner dispatchSelectionChangeIfNeeded];
-//  });
-//}
-
+// Helper: Calculate minimal diff range between two strings
+- (NSRange)calculateDiffRange:(NSString *)oldText newText:(NSString *)newText {
+  NSInteger oldLen = oldText.length;
+  NSInteger newLen = newText.length;
+  
+  // Find common prefix
+  NSInteger prefixLen = 0;
+  NSInteger minLen = MIN(oldLen, newLen);
+  
+  while (prefixLen < minLen &&
+         [oldText characterAtIndex:prefixLen] == [newText characterAtIndex:prefixLen]) {
+    prefixLen++;
+  }
+  
+  // Find common suffix
+  NSInteger suffixLen = 0;
+  while (suffixLen < (minLen - prefixLen) &&
+         [oldText characterAtIndex:(oldLen - suffixLen - 1)] ==
+         [newText characterAtIndex:(newLen - suffixLen - 1)]) {
+    suffixLen++;
+  }
+  
+  // Return range in old text that needs to be replaced
+  NSInteger location = prefixLen;
+  NSInteger length = oldLen - prefixLen - suffixLen;
+  
+  return NSMakeRange(location, length);
+}
 
 /// setSelection(start, end)
 - (void)setSelectionStart:(NSInteger)start end:(NSInteger)end {
@@ -279,30 +247,146 @@
   };
 }
 
-//static NSRange DiffRange(NSString *oldText, NSString *newText) {
-//  NSInteger oldLen = oldText.length;
-//  NSInteger newLen = newText.length;
+/// setText() - legacy, buggy and non undoable
+//- (void)setText:(NSString *)text
+//{
+//  UITextView *tv = _textView;
+//  TypeRichTextInputView *owner = _owner;
+//  if (!tv || !owner) return;
 //
-//  NSInteger start = 0;
-//  while (start < oldLen &&
-//         start < newLen &&
-//         [oldText characterAtIndex:start] ==
-//         [newText characterAtIndex:start]) {
-//    start++;
-//  }
 //
-//  NSInteger endOld = oldLen;
-//  NSInteger endNew = newLen;
+//    dispatch_async(dispatch_get_main_queue(), ^{
+//      if (tv.markedTextRange) return;
+//      if (owner.isUserTyping) return;
 //
-//  while (endOld > start &&
-//         endNew > start &&
-//         [oldText characterAtIndex:endOld - 1] ==
-//         [newText characterAtIndex:endNew - 1]) {
-//    endOld--;
-//    endNew--;
-//  }
+//      NSString *newText = text ?: @"";
 //
-//  return NSMakeRange(start, endOld - start);
+//      owner.blockEmitting = YES;
+//
+//      NSTextStorage *storage = tv.textStorage;
+//
+//      NSRange oldSelection = tv.selectedRange;
+//
+//      NSDictionary *attrs = [self baseAttributesForTextView:tv];
+//
+//      NSAttributedString *attrText =
+//        [[NSAttributedString alloc] initWithString:newText
+//                                        attributes:attrs];
+//
+//      [storage beginEditing];
+//      [storage setAttributedString:attrText];
+//      [storage endEditing];
+//
+//      // Clamp & restore selection
+//      NSInteger max = newText.length;
+//      NSInteger loc = MIN(oldSelection.location, max);
+//      NSInteger len = MIN(oldSelection.length, max - loc);
+//      tv.selectedRange = NSMakeRange(loc, len);
+//
+//      owner.blockEmitting = NO;
+//
+//      [owner updatePlaceholderVisibilityFromCommand];
+//      [owner invalidateTextLayoutFromCommand];
+//      [owner dispatchSelectionChangeIfNeeded];
+////
+////    // Restore cursor (clamped)
+////    NSInteger safeOffset = MIN(cursorOffset, newText.length);
+////    UITextPosition *pos =
+////      [tv positionFromPosition:tv.beginningOfDocument
+////                        offset:safeOffset];
+////
+////    if (pos) {
+////      tv.selectedTextRange =
+////        [tv textRangeFromPosition:pos toPosition:pos];
+////    }
+////
+////    owner.blockEmitting = NO;
+////
+////    [owner updatePlaceholderVisibilityFromCommand];
+////    [owner invalidateTextLayoutFromCommand];
+////    [owner dispatchSelectionChangeIfNeeded];
+//  });
+//}
+
+
+/// setText(text) — undoable, cursor-safe, IME-safe
+//- (void)setText:(NSString *)text
+//{
+//  UITextView *tv = _textView;
+//  TypeRichTextInputView *owner = _owner;
+//  if (!tv || !owner) return;
+//
+//  dispatch_async(dispatch_get_main_queue(), ^{
+//    // Never touch text while IME composing
+//    if (tv.markedTextRange) return;
+//
+//    NSString *newText = text ?: @"";
+//    NSString *oldText = tv.text ?: @"";
+//
+//    // No-op fast path
+//    if ([oldText isEqualToString:newText]) {
+//      return;
+//    }
+//
+//    owner.blockEmitting = YES;
+//
+//    // Save selection (cursor)
+//    NSRange oldSelection = tv.selectedRange;
+//
+//    // Compute minimal diff range
+//    NSRange replaceRange = DiffRange(oldText, newText);
+//
+//    NSInteger insertStart = replaceRange.location;
+//    NSInteger insertLength =
+//      newText.length - (oldText.length - replaceRange.length);
+//
+//    NSString *insertText =
+//      insertLength > 0
+//        ? [newText substringWithRange:
+//            NSMakeRange(insertStart, insertLength)]
+//        : @"";
+//
+//    // Convert NSRange → UITextRange
+//    UITextPosition *start =
+//      [tv positionFromPosition:tv.beginningOfDocument
+//                        offset:replaceRange.location];
+//    UITextPosition *end =
+//      [tv positionFromPosition:tv.beginningOfDocument
+//                        offset:NSMaxRange(replaceRange)];
+//
+//    if (!start || !end) {
+//      owner.blockEmitting = NO;
+//      return;
+//    }
+//
+//    UITextRange *uiRange =
+//      [tv textRangeFromPosition:start toPosition:end];
+//
+//    // THIS IS THE KEY LINE (undo-safe)
+//    [tv replaceRange:uiRange withText:insertText];
+//
+//    // ---- Restore selection correctly ----
+//    NSInteger delta = insertText.length - replaceRange.length;
+//
+//    NSInteger newLoc = oldSelection.location;
+//    NSInteger newLen = oldSelection.length;
+//
+//    if (oldSelection.location > replaceRange.location) {
+//      newLoc = MAX(0, newLoc + delta);
+//    }
+//
+//    NSInteger max = tv.text.length;
+//    newLoc = MIN(newLoc, max);
+//    newLen = MIN(newLen, max - newLoc);
+//
+//    tv.selectedRange = NSMakeRange(newLoc, newLen);
+//
+//    owner.blockEmitting = NO;
+//
+//    [owner updatePlaceholderVisibilityFromCommand];
+//    [owner invalidateTextLayoutFromCommand];
+//    [owner dispatchSelectionChangeIfNeeded];
+//  });
 //}
 
 @end

--- a/src/TypeRichTextInput.tsx
+++ b/src/TypeRichTextInput.tsx
@@ -39,6 +39,8 @@ const TypeRichTextInput = forwardRef(
   (props: TypeRichTextInputProps, ref: Ref<TypeRichTextInputRef>) => {
     const nativeRef = useRef(null);
 
+    const { scrollEnabled = true, ...restProps } = props;
+
     useImperativeHandle(ref, () => ({
       focus: () => {
         if (nativeRef.current) {
@@ -110,7 +112,8 @@ const TypeRichTextInput = forwardRef(
     return (
       <NativeTypeRichTextInput
         ref={nativeRef}
-        {...props}
+        {...restProps}
+        scrollEnabled={scrollEnabled}
         onInputFocus={() => props.onFocus?.()}
         onInputBlur={() => props.onBlur?.()}
         onChangeText={handleOnChangeTextEvent}


### PR DESCRIPTION
older setText() had random cursor jumps while handling text via controlled input

new:
Implemented diff-based text replacement with smart cursor tracking:
**Key Changes:**

- **Diff-based setText:** Only replaces changed portions instead of entire text, preserving cursor context
- **Smart cursor adjustment:** Calculates cursor delta based on change location relative to cursor position